### PR TITLE
Calling this.scrollTo(..) instead of scrollTo(..) in repeater.js 

### DIFF
--- a/wicket-quickview/src/main/java/com/aplombee/repeater.js
+++ b/wicket-quickview/src/main/java/com/aplombee/repeater.js
@@ -72,13 +72,13 @@ var QuickView = {
     scrollToBottom: function(id)
     {
         var element = $("#" + id);
-        scrollTo(id, $(element).height());
+        this.scrollTo(id, $(element).height());
     },
     /**
      position the scrollbar to top
      */
     scrollToTop: function(id) {
-        scrollTo(id, 0);
+        this.scrollTo(id, 0);
     },
     /**
      position the scrollbar to provided height


### PR DESCRIPTION
When using javascript functions from QuickView we found out that QuickView.scrollToBottom and QuickView.scrollToTop don't work for us. During the investigation we found out that the code in repeater.js tries to call window.scrollTo function instead of QuickView.scrollTo. This change should fix it. We are using wicket 6.x so if you decide to merge we would appreciate backporting this change to your 6.x branch.
